### PR TITLE
Fix ON/OFF enum mapping

### DIFF
--- a/custom_components/electrolux_status/api.py
+++ b/custom_components/electrolux_status/api.py
@@ -243,6 +243,10 @@ class ElectroluxLibraryEntity:
             and isinstance(values, dict)
             and len(values) > 0
         ):
+            if type_object == "string":
+                upper_values = {str(k).upper() for k in values}
+                if upper_values == {"ON", "OFF"}:
+                    return SWITCH
             if (
                 type_object not in ["number", "temperature"]
                 or capability_def.get("min", None) is None


### PR DESCRIPTION
## Summary
- adjust entity type detection to treat ON/OFF string enums as switches

## Testing
- `pytest -q`
- `python -m py_compile custom_components/electrolux_status/api.py`


------
https://chatgpt.com/codex/tasks/task_e_685e5580fda4832eada0fe1bbc36d786